### PR TITLE
Fix RDS dabtabase name in graphite.

### DIFF
--- a/sample_templates/rds.yml.j2
+++ b/sample_templates/rds.yml.j2
@@ -36,6 +36,6 @@ Metrics:
   Dimensions:
     DBInstanceIdentifier: "{{ rds.id }}"
   Options:
-    Formatter: 'cloudwatch.%(Namespace)s.{{ rds }}.%(MetricName)s.%(statistic)s.%(Unit)s'
+    Formatter: 'cloudwatch.%(Namespace)s.{{ rds.id }}.%(MetricName)s.%(statistic)s.%(Unit)s'
   {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
Instead of dbinstance:rds-instance-name now we can have only rds-instance-name.